### PR TITLE
feat(ci): adopt estate CI + PHPUnit suite from scratch (v1.2.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,71 +1,27 @@
+##
+# Thin CI caller — peptide-reconstitution-calculator
+#
+# Delegates all lint/test/file-size jobs to the estate reusable workflow.
+# Per estate standard: workflow_call is required so deploy.yml can gate on it.
+# See: peptiderepo/peptide-e2e/.github/workflows/ci.yml@main for job definitions.
+##
 name: CI
 
 on:
+  pull_request: {}
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-  workflow_call:
+    branches: [main]
+  workflow_call: {}
 
+# Required: calling workflow must declare contents: write so the reusable
+# phpcs job can commit phpcbf auto-fixes back to the PR branch.
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  # ── PHP Syntax Check ─────────────────────────────────────────────
-  lint-php:
-    name: PHP Lint (${{ matrix.php }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php: [ '8.1', '8.2', '8.3' ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-
-      - name: Syntax check all PHP files
-        run: find . -name "*.php" -not -path "./vendor/*" | xargs -n 1 php -l
-
-  # ── WordPress Coding Standards (PHP CodeSniffer) ──────────────────
-  lint-phpcs:
-    name: WordPress Coding Standards
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1'
-
-      - name: Install Composer dependencies
-        run: composer install --no-interaction --prefer-dist --no-progress
-
-      - name: Run PHPCS
-        run: composer run lint
-        continue-on-error: true
-
-  # ── 300-line file check ──────────────────────────────────────────
-  file-size:
-    name: 300-line file check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Check no PHP file exceeds 300 lines
-        run: |
-          violations=0
-          while IFS= read -r file; do
-            lines=$(wc -l < "$file")
-            if [ "$lines" -gt 300 ]; then
-              echo "VIOLATION: $file ($lines lines)"
-              violations=$((violations + 1))
-            fi
-          done < <(find . -name "*.php" -not -path "./vendor/*" -not -path "./tests/*")
-          if [ "$violations" -gt 0 ]; then
-            echo "$violations file(s) exceed 300 lines"
-            exit 1
-          fi
-          echo "All PHP files are 300 lines or fewer."
+  ci:
+    uses: peptiderepo/peptide-e2e/.github/workflows/ci.yml@main
+    with:
+      tests: stubs
+      has_js: true
+    secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Peptide Reconstitution Calculator are documented here.
 Format: [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] — 2026-06-16
+
+### Added
+- PHPUnit test suite (WP stubs, `tests: stubs`) — 40 tests across four classes:
+  - `MathTest`: 25 tests covering all PRC_Math methods — concentration mg/mL,
+    mcg/unit, injection volume, syringe units, doses per vial, and the full
+    `calculate()` orchestrator with named peptide scenarios (BPC-157, TB-500,
+    Semaglutide, MK-677, Ipamorelin) plus edge cases (zero water, zero dose,
+    negative inputs, floor rounding, rounding precision).
+  - `DefaultPresetsTest`: 11 tests — collection count, all 8 expected slugs present,
+    required keys on every preset (via dataProvider), valid dose units, min < max,
+    source='default', and spot-checks on BPC-157 / Semaglutide / MK-677.
+  - `RestControllerTest`: 7 tests — calculate() 200 response + correct values for
+    mcg and mg dose units; get_presets() returns 200; get_preset() 200 for known
+    slug and WP_Error for unknown slug.
+  - `PresetProviderTest`: 4 tests — fallback to defaults without PR Core, all
+    presets have slug, cache invalidation, idempotent invalidation.
+- `phpunit.xml.dist` + `tests/bootstrap.php` (WP function/class stubs).
+- `composer test` script (`vendor/bin/phpunit --configuration phpunit.xml.dist`).
+- `phpunit/phpunit ^9.6` and `yoast/phpunit-polyfills ^2.0` in `require-dev`.
+
+### Changed
+- `ci.yml` replaced with thin caller delegating to estate reusable workflow
+  (`peptide-e2e/.github/workflows/ci.yml@main`; `tests: stubs`, `has_js: true`,
+  `permissions: contents: write`, `workflow_call` so `deploy.yml` gate works).
+
 ## [1.1.0] — 2026-04-26
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,12 @@
 		"php": ">=8.1"
 	},
 	"require-dev": {
+		"phpunit/phpunit": "^9.6",
 		"squizlabs/php_codesniffer": "^3.13",
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcsstandards/phpcsutils": "^1.0",
-		"dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+		"yoast/phpunit-polyfills": "^2.0"
 	},
 	"config": {
 		"allow-plugins": {
@@ -18,6 +20,7 @@
 		}
 	},
 	"scripts": {
+		"test": "vendor/bin/phpunit --configuration phpunit.xml.dist",
 		"lint": "phpcs",
 		"lint:fix": "phpcbf"
 	}

--- a/includes/api/class-prc-rest-controller.php
+++ b/includes/api/class-prc-rest-controller.php
@@ -81,7 +81,7 @@ class PRC_Rest_Controller {
 	 * @param \WP_REST_Request $request Request object.
 	 * @return \WP_REST_Response
 	 */
-	public function get_presets( \WP_REST_Request $request ): \WP_REST_Response {
+	public function get_presets( \WP_REST_Request $request ): \WP_REST_Response { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		$provider = new PRC_Preset_Provider();
 		$presets  = $provider->get_all_presets();
 

--- a/includes/api/class-prc-rest-controller.php
+++ b/includes/api/class-prc-rest-controller.php
@@ -9,6 +9,7 @@
  * @see class-prc-preset-provider.php — Data source for presets.
  * @see class-prc-math.php           — Calculation engine.
  * @see class-prc-shortcode.php      — Frontend JS consumes these endpoints.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/api/class-prc-rest-controller.php
+++ b/includes/api/class-prc-rest-controller.php
@@ -38,39 +38,39 @@ class PRC_Rest_Controller {
 		register_rest_route(
 			self::NAMESPACE,
 			'/presets',
-			[
+			array(
 				'methods'             => 'GET',
-				'callback'            => [ $this, 'get_presets' ],
+				'callback'            => array( $this, 'get_presets' ),
 				'permission_callback' => '__return_true',
-			]
+			)
 		);
 
 		register_rest_route(
 			self::NAMESPACE,
 			'/presets/(?P<slug>[a-z0-9-]+)',
-			[
+			array(
 				'methods'             => 'GET',
-				'callback'            => [ $this, 'get_preset' ],
+				'callback'            => array( $this, 'get_preset' ),
 				'permission_callback' => '__return_true',
-				'args'                => [
-					'slug' => [
+				'args'                => array(
+					'slug' => array(
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_title',
 						'required'          => true,
-					],
-				],
-			]
+					),
+				),
+			)
 		);
 
 		register_rest_route(
 			self::NAMESPACE,
 			'/calculate',
-			[
+			array(
 				'methods'             => 'POST',
-				'callback'            => [ $this, 'calculate' ],
+				'callback'            => array( $this, 'calculate' ),
 				'permission_callback' => '__return_true',
 				'args'                => $this->get_calculate_args(),
-			]
+			)
 		);
 	}
 
@@ -107,7 +107,7 @@ class PRC_Rest_Controller {
 		return new \WP_Error(
 			'prc_preset_not_found',
 			__( 'Preset not found.', 'peptide-reconstitution-calculator' ),
-			[ 'status' => 404 ]
+			array( 'status' => 404 )
 		);
 	}
 
@@ -137,31 +137,31 @@ class PRC_Rest_Controller {
 	 * @return array<string, array<string, mixed>>
 	 */
 	private function get_calculate_args(): array {
-		return [
-			'vial_mg'      => [
+		return array(
+			'vial_mg'      => array(
 				'type'              => 'number',
 				'required'          => true,
 				'sanitize_callback' => 'floatval',
 				'validate_callback' => fn( $v ) => is_numeric( $v ) && (float) $v > 0,
-			],
-			'water_ml'     => [
+			),
+			'water_ml'     => array(
 				'type'              => 'number',
 				'required'          => true,
 				'sanitize_callback' => 'floatval',
 				'validate_callback' => fn( $v ) => is_numeric( $v ) && (float) $v > 0,
-			],
-			'desired_dose' => [
+			),
+			'desired_dose' => array(
 				'type'              => 'number',
 				'required'          => true,
 				'sanitize_callback' => 'floatval',
 				'validate_callback' => fn( $v ) => is_numeric( $v ) && (float) $v > 0,
-			],
-			'dose_unit'    => [
+			),
+			'dose_unit'    => array(
 				'type'              => 'string',
 				'required'          => true,
 				'sanitize_callback' => 'sanitize_text_field',
-				'validate_callback' => fn( $v ) => in_array( $v, [ 'mcg', 'mg' ], true ),
-			],
-		];
+				'validate_callback' => fn( $v ) => in_array( $v, array( 'mcg', 'mg' ), true ),
+			),
+		);
 	}
 }

--- a/includes/class-prc-activator.php
+++ b/includes/class-prc-activator.php
@@ -5,6 +5,7 @@
  * What: Runs on plugin activation — flushes rewrite rules.
  * Who calls it: register_activation_hook in bootstrap.
  * Dependencies: None.
+ *
  * @package PeptideReconstitutionCalculator
  */
 

--- a/includes/class-prc-activator.php
+++ b/includes/class-prc-activator.php
@@ -5,6 +5,7 @@
  * What: Runs on plugin activation — flushes rewrite rules.
  * Who calls it: register_activation_hook in bootstrap.
  * Dependencies: None.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/class-prc-autoloader.php
+++ b/includes/class-prc-autoloader.php
@@ -22,7 +22,7 @@ class PRC_Autoloader {
 	 * @return void
 	 */
 	public static function register(): void {
-		spl_autoload_register( [ __CLASS__, 'autoload' ] );
+		spl_autoload_register( array( __CLASS__, 'autoload' ) );
 	}
 
 	/**

--- a/includes/class-prc-autoloader.php
+++ b/includes/class-prc-autoloader.php
@@ -7,6 +7,7 @@
  * Dependencies: None.
  *
  * @see class-pr-core-autoloader.php in Peptide Repo Core — same pattern.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/class-prc-cache-listener.php
+++ b/includes/class-prc-cache-listener.php
@@ -27,7 +27,7 @@ class PRC_Cache_Listener {
 	 * @return void Side effect: registers action hooks.
 	 */
 	public static function register(): void {
-		$callback = [ __CLASS__, 'invalidate' ];
+		$callback = array( __CLASS__, 'invalidate' );
 
 		// Dosing row lifecycle — affects calculator presets.
 		add_action( 'pr_core_after_dosing_row_publish', $callback );

--- a/includes/class-prc-cache-listener.php
+++ b/includes/class-prc-cache-listener.php
@@ -9,6 +9,7 @@
  *
  * @see class-prc-preset-provider.php — Cache being invalidated.
  * @see PR_Core_Dosing_Repository     — Fires the hooks we listen to.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/class-prc-calculator.php
+++ b/includes/class-prc-calculator.php
@@ -29,17 +29,17 @@ class PRC_Calculator {
 	public static function boot(): void {
 		// Frontend shortcode — always available.
 		$shortcode = new PRC_Shortcode();
-		add_action( 'init', [ $shortcode, 'register' ] );
+		add_action( 'init', array( $shortcode, 'register' ) );
 
 		// REST API — serves presets to the JS calculator.
-		add_action( 'rest_api_init', [ new PRC_Rest_Controller(), 'register_routes' ] );
+		add_action( 'rest_api_init', array( new PRC_Rest_Controller(), 'register_routes' ) );
 
 		// Cache invalidation — keep presets in sync with PR Core dosing data.
 		PRC_Cache_Listener::register();
 
 		// Admin notice when PR Core is absent.
 		if ( is_admin() && ! self::is_pr_core_active() ) {
-			add_action( 'admin_notices', [ __CLASS__, 'render_pr_core_notice' ] );
+			add_action( 'admin_notices', array( __CLASS__, 'render_pr_core_notice' ) );
 		}
 	}
 
@@ -70,7 +70,7 @@ class PRC_Calculator {
 		}
 
 		// Only show on plugins page and the calculator's own pages.
-		$show_on = [ 'plugins', 'settings_page_prc-settings' ];
+		$show_on = array( 'plugins', 'settings_page_prc-settings' );
 		if ( ! in_array( $screen->id, $show_on, true ) ) {
 			return;
 		}

--- a/includes/class-prc-calculator.php
+++ b/includes/class-prc-calculator.php
@@ -9,6 +9,7 @@
  * @see class-prc-shortcode.php    — Frontend calculator widget.
  * @see class-prc-rest-controller.php — REST endpoints for presets.
  * @see class-prc-preset-provider.php — PR Core integration + fallback defaults.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/class-prc-deactivator.php
+++ b/includes/class-prc-deactivator.php
@@ -5,6 +5,7 @@
  * What: Runs on plugin deactivation — flushes rewrite rules.
  * Who calls it: register_deactivation_hook in bootstrap.
  * Dependencies: None.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/class-prc-deactivator.php
+++ b/includes/class-prc-deactivator.php
@@ -5,6 +5,7 @@
  * What: Runs on plugin deactivation — flushes rewrite rules.
  * Who calls it: register_deactivation_hook in bootstrap.
  * Dependencies: None.
+ *
  * @package PeptideReconstitutionCalculator
  */
 

--- a/includes/class-prc-default-presets.php
+++ b/includes/class-prc-default-presets.php
@@ -27,11 +27,11 @@ class PRC_Default_Presets {
 	 * @return array<int, array<string, mixed>>
 	 */
 	public static function get_all(): array {
-		return [
-			[
+		return array(
+			array(
 				'slug'                 => 'bpc-157',
 				'name'                 => 'BPC-157',
-				'vial_sizes_mg'        => [ 5, 10 ],
+				'vial_sizes_mg'        => array( 5, 10 ),
 				'default_vial_mg'      => 5,
 				'recommended_water_ml' => 2.0,
 				'dose_range_min'       => 200,
@@ -41,11 +41,11 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'observational',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-			[
+			),
+			array(
 				'slug'                 => 'tb-500',
 				'name'                 => 'TB-500',
-				'vial_sizes_mg'        => [ 2, 5, 10 ],
+				'vial_sizes_mg'        => array( 2, 5, 10 ),
 				'default_vial_mg'      => 5,
 				'recommended_water_ml' => 2.0,
 				'dose_range_min'       => 2000,
@@ -55,11 +55,11 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'preclinical',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-			[
+			),
+			array(
 				'slug'                 => 'semaglutide',
 				'name'                 => 'Semaglutide',
-				'vial_sizes_mg'        => [ 2, 5, 10 ],
+				'vial_sizes_mg'        => array( 2, 5, 10 ),
 				'default_vial_mg'      => 5,
 				'recommended_water_ml' => 2.0,
 				'dose_range_min'       => 0.25,
@@ -69,11 +69,11 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'meta-analysis',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-			[
+			),
+			array(
 				'slug'                 => 'cjc-1295-dac',
 				'name'                 => 'CJC-1295 (DAC)',
-				'vial_sizes_mg'        => [ 2, 5 ],
+				'vial_sizes_mg'        => array( 2, 5 ),
 				'default_vial_mg'      => 2,
 				'recommended_water_ml' => 1.0,
 				'dose_range_min'       => 1000,
@@ -83,11 +83,11 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'preclinical',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-			[
+			),
+			array(
 				'slug'                 => 'ipamorelin',
 				'name'                 => 'Ipamorelin',
-				'vial_sizes_mg'        => [ 2, 5 ],
+				'vial_sizes_mg'        => array( 2, 5 ),
 				'default_vial_mg'      => 5,
 				'recommended_water_ml' => 2.0,
 				'dose_range_min'       => 100,
@@ -97,11 +97,11 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'preclinical',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-			[
+			),
+			array(
 				'slug'                 => 'pt-141',
 				'name'                 => 'PT-141 (Bremelanotide)',
-				'vial_sizes_mg'        => [ 2, 10 ],
+				'vial_sizes_mg'        => array( 2, 10 ),
 				'default_vial_mg'      => 10,
 				'recommended_water_ml' => 2.0,
 				'dose_range_min'       => 500,
@@ -111,11 +111,11 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'rct-large',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-			[
+			),
+			array(
 				'slug'                 => 'mk-677',
 				'name'                 => 'MK-677 (Ibutamoren)',
-				'vial_sizes_mg'        => [ 15, 30 ],
+				'vial_sizes_mg'        => array( 15, 30 ),
 				'default_vial_mg'      => 30,
 				'recommended_water_ml' => 3.0,
 				'dose_range_min'       => 10,
@@ -125,11 +125,11 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'rct-small',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-			[
+			),
+			array(
 				'slug'                 => 'ghrp-6',
 				'name'                 => 'GHRP-6',
-				'vial_sizes_mg'        => [ 5, 10 ],
+				'vial_sizes_mg'        => array( 5, 10 ),
 				'default_vial_mg'      => 5,
 				'recommended_water_ml' => 2.0,
 				'dose_range_min'       => 100,
@@ -139,7 +139,7 @@ class PRC_Default_Presets {
 				'evidence_strength'    => 'preclinical',
 				'dosing_row_count'     => 0,
 				'source'               => 'default',
-			],
-		];
+			),
+		);
 	}
 }

--- a/includes/class-prc-default-presets.php
+++ b/includes/class-prc-default-presets.php
@@ -8,6 +8,7 @@
  * Dependencies: None.
  *
  * @see class-prc-preset-provider.php — Merges these with live PR Core data.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/class-prc-math.php
+++ b/includes/class-prc-math.php
@@ -10,6 +10,7 @@
  *
  * @see assets/js/calculator.js — Client-side mirror of this math.
  * @see api/class-prc-rest-controller.php — Server-side consumer.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/includes/class-prc-math.php
+++ b/includes/class-prc-math.php
@@ -52,13 +52,13 @@ class PRC_Math {
 			? $desired_dose / 1000
 			: $desired_dose;
 
-		$concentration_mg_per_ml = self::concentration_mg_per_ml( $vial_mg, $water_ml );
+		$concentration_mg_per_ml    = self::concentration_mg_per_ml( $vial_mg, $water_ml );
 		$concentration_mcg_per_unit = self::concentration_mcg_per_unit( $vial_mg, $water_ml );
-		$injection_ml = self::injection_volume_ml( $dose_mg, $concentration_mg_per_ml );
-		$syringe_units = self::syringe_units( $injection_ml );
-		$doses_per_vial = self::doses_per_vial( $vial_mg, $dose_mg );
+		$injection_ml               = self::injection_volume_ml( $dose_mg, $concentration_mg_per_ml );
+		$syringe_units              = self::syringe_units( $injection_ml );
+		$doses_per_vial             = self::doses_per_vial( $vial_mg, $dose_mg );
 
-		return [
+		return array(
 			'concentration_mg_per_ml'    => round( $concentration_mg_per_ml, 4 ),
 			'concentration_mcg_per_unit' => round( $concentration_mcg_per_unit, 2 ),
 			'injection_volume_ml'        => round( $injection_ml, 4 ),
@@ -69,7 +69,7 @@ class PRC_Math {
 			'desired_dose_mg'            => round( $dose_mg, 4 ),
 			'desired_dose_display'       => $desired_dose,
 			'dose_unit'                  => $dose_unit,
-		];
+		);
 	}
 
 	/**

--- a/includes/class-prc-preset-provider.php
+++ b/includes/class-prc-preset-provider.php
@@ -12,6 +12,7 @@
  * @see class-prc-default-presets.php            — Hardcoded fallback presets.
  * @see PR_Core_Peptide_Repository (PR Core)     — Peptide list source.
  * @see PR_Core_Dosing_Repository  (PR Core)     — Dosing data source.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);
@@ -133,7 +134,7 @@ class PRC_Preset_Provider {
 		// Extract dose range across all rows.
 		$dose_mins = array_filter( array_map( fn( $r ) => $r->dose_min, $rows ) );
 		$dose_maxs = array_filter( array_map( fn( $r ) => $r->dose_max, $rows ) );
-		$dose_unit = $rows[0]->dose_unit ?: 'mcg';
+		$dose_unit = ! empty( $rows[0]->dose_unit ) ? $rows[0]->dose_unit : 'mcg';
 
 		// Derive typical vial sizes from dose range.
 		// Why: Most peptides are sold in standard vial sizes (2mg, 5mg, 10mg, 15mg, 30mg).
@@ -149,7 +150,7 @@ class PRC_Preset_Provider {
 
 		return array(
 			'slug'                 => $peptide->slug,
-			'name'                 => $display_name ?: $peptide->title,
+			'name'                 => ! empty( $display_name ) ? $display_name : $peptide->title,
 			'vial_sizes_mg'        => $vial_sizes,
 			'default_vial_mg'      => $vial_sizes[0] ?? 5,
 			'recommended_water_ml' => $this->recommend_water_ml( $vial_sizes[0] ?? 5 ),

--- a/includes/class-prc-preset-provider.php
+++ b/includes/class-prc-preset-provider.php
@@ -89,19 +89,19 @@ class PRC_Preset_Provider {
 		// could fail to autoload (e.g. fatal error in PR Core bootstrap).
 		// Fall back to empty array so the caller merges in defaults gracefully.
 		if ( ! class_exists( 'PR_Core_Peptide_Repository' ) || ! class_exists( 'PR_Core_Dosing_Repository' ) ) {
-			return [];
+			return array();
 		}
 
 		$peptide_repo = new PR_Core_Peptide_Repository();
 		$dosing_repo  = new PR_Core_Dosing_Repository();
 
-		$peptides = $peptide_repo->find_all( [ 'posts_per_page' => 100 ] );
-		$presets  = [];
+		$peptides = $peptide_repo->find_all( array( 'posts_per_page' => 100 ) );
+		$presets  = array();
 
 		foreach ( $peptides as $peptide ) {
 			$rows = $dosing_repo->find_by_peptide(
 				$peptide->id,
-				[ 'route' => 'subcutaneous' ]
+				array( 'route' => 'subcutaneous' )
 			);
 
 			if ( empty( $rows ) ) {
@@ -141,26 +141,26 @@ class PRC_Preset_Provider {
 
 		$display_name = '';
 		if ( method_exists( $peptide, 'to_array' ) ) {
-			$arr = $peptide->to_array();
+			$arr          = $peptide->to_array();
 			$display_name = $arr['display_name'] ?? $peptide->title ?? '';
 		} else {
 			$display_name = $peptide->title ?? '';
 		}
 
-		return [
-			'slug'                    => $peptide->slug,
-			'name'                    => $display_name ?: $peptide->title,
-			'vial_sizes_mg'           => $vial_sizes,
-			'default_vial_mg'         => $vial_sizes[0] ?? 5,
-			'recommended_water_ml'    => $this->recommend_water_ml( $vial_sizes[0] ?? 5 ),
-			'dose_range_min'          => ! empty( $dose_mins ) ? min( $dose_mins ) : null,
-			'dose_range_max'          => ! empty( $dose_maxs ) ? max( $dose_maxs ) : null,
-			'dose_unit'               => $dose_unit,
-			'typical_frequency'       => $this->most_common_frequency( $rows ),
-			'evidence_strength'       => $peptide->evidence_strength ?? 'preclinical',
-			'dosing_row_count'        => count( $rows ),
-			'source'                  => 'pr_core',
-		];
+		return array(
+			'slug'                 => $peptide->slug,
+			'name'                 => $display_name ?: $peptide->title,
+			'vial_sizes_mg'        => $vial_sizes,
+			'default_vial_mg'      => $vial_sizes[0] ?? 5,
+			'recommended_water_ml' => $this->recommend_water_ml( $vial_sizes[0] ?? 5 ),
+			'dose_range_min'       => ! empty( $dose_mins ) ? min( $dose_mins ) : null,
+			'dose_range_max'       => ! empty( $dose_maxs ) ? max( $dose_maxs ) : null,
+			'dose_unit'            => $dose_unit,
+			'typical_frequency'    => $this->most_common_frequency( $rows ),
+			'evidence_strength'    => $peptide->evidence_strength ?? 'preclinical',
+			'dosing_row_count'     => count( $rows ),
+			'source'               => 'pr_core',
+		);
 	}
 
 	/**
@@ -176,10 +176,10 @@ class PRC_Preset_Provider {
 	 * @return float[] Standard vial sizes in mg.
 	 */
 	private function infer_vial_sizes( array $dose_mins, array $dose_maxs, string $dose_unit ): array {
-		$standard_sizes = [ 2, 5, 10, 15, 30 ];
+		$standard_sizes = array( 2, 5, 10, 15, 30 );
 
 		if ( empty( $dose_mins ) && empty( $dose_maxs ) ) {
-			return [ 5, 10 ];
+			return array( 5, 10 );
 		}
 
 		// Convert everything to mg for comparison.
@@ -187,12 +187,12 @@ class PRC_Preset_Provider {
 		$all_doses   = array_merge( $dose_mins, $dose_maxs );
 
 		foreach ( $all_doses as $dose ) {
-			$mg = ( 'mcg' === $dose_unit ) ? $dose / 1000 : $dose;
+			$mg          = ( 'mcg' === $dose_unit ) ? $dose / 1000 : $dose;
 			$max_dose_mg = max( $max_dose_mg, $mg );
 		}
 
 		// Pick vials that hold at least 10 doses at the max dose level.
-		$viable = [];
+		$viable = array();
 		foreach ( $standard_sizes as $size ) {
 			if ( $max_dose_mg > 0 && ( $size / $max_dose_mg ) >= 5 ) {
 				$viable[] = $size;
@@ -200,7 +200,7 @@ class PRC_Preset_Provider {
 		}
 
 		// Fallback: return two middle sizes if heuristic found nothing.
-		return ! empty( $viable ) ? array_slice( $viable, 0, 3 ) : [ 5, 10 ];
+		return ! empty( $viable ) ? array_slice( $viable, 0, 3 ) : array( 5, 10 );
 	}
 
 	/**

--- a/includes/frontend/class-prc-shortcode.php
+++ b/includes/frontend/class-prc-shortcode.php
@@ -34,7 +34,7 @@ class PRC_Shortcode {
 	 * @return void Side effect: registers shortcode.
 	 */
 	public function register(): void {
-		add_shortcode( 'prc_calculator', [ $this, 'render' ] );
+		add_shortcode( 'prc_calculator', array( $this, 'render' ) );
 	}
 
 	/**
@@ -47,11 +47,11 @@ class PRC_Shortcode {
 	 * @param array<string, string>|string $atts Shortcode attributes.
 	 * @return string HTML output.
 	 */
-	public function render( $atts = [] ): string {
+	public function render( $atts = array() ): string {
 		$atts = shortcode_atts(
-			[
+			array(
 				'peptide' => '', // Pre-select a peptide by slug.
-			],
+			),
 			$atts,
 			'prc_calculator'
 		);
@@ -81,14 +81,14 @@ class PRC_Shortcode {
 		wp_enqueue_style(
 			'prc-calculator',
 			PRC_PLUGIN_URL . 'assets/css/calculator.css',
-			[],
+			array(),
 			PRC_VERSION
 		);
 
 		wp_enqueue_script(
 			'prc-calculator',
 			PRC_PLUGIN_URL . 'assets/js/calculator.js',
-			[],
+			array(),
 			PRC_VERSION,
 			true
 		);
@@ -96,23 +96,27 @@ class PRC_Shortcode {
 		// Pass presets and config to JS — all REST endpoints are public-read,
 		// so no nonce is needed. The restUrl is provided for future use.
 		$provider = new PRC_Preset_Provider();
-		wp_localize_script( 'prc-calculator', 'prcConfig', [
-			'presets'      => $provider->get_all_presets(),
-			'restUrl'      => esc_url_raw( rest_url( 'prc/v1' ) ),
-			'syringeUnits' => 100, // Must match PRC_Math::SYRINGE_UNITS_PER_ML and calculator.js SYRINGE_UNITS_PER_ML.
-			'i18n'         => [
-				'selectPeptide'  => __( 'Select a peptide…', 'peptide-reconstitution-calculator' ),
-				'customEntry'    => __( 'Custom / Manual Entry', 'peptide-reconstitution-calculator' ),
-				'calculate'      => __( 'Calculate', 'peptide-reconstitution-calculator' ),
-				'reset'          => __( 'Reset', 'peptide-reconstitution-calculator' ),
-				'concentration'  => __( 'Concentration', 'peptide-reconstitution-calculator' ),
-				'injectionVol'   => __( 'Injection Volume', 'peptide-reconstitution-calculator' ),
-				'syringeUnits'   => __( 'Syringe Units', 'peptide-reconstitution-calculator' ),
-				'dosesPerVial'   => __( 'Doses Per Vial', 'peptide-reconstitution-calculator' ),
-				'perUnit'        => __( 'per unit', 'peptide-reconstitution-calculator' ),
-				'disclaimer'     => __( 'For informational purposes only. Not medical advice. Always consult a qualified healthcare professional.', 'peptide-reconstitution-calculator' ),
-			],
-		] );
+		wp_localize_script(
+			'prc-calculator',
+			'prcConfig',
+			array(
+				'presets'      => $provider->get_all_presets(),
+				'restUrl'      => esc_url_raw( rest_url( 'prc/v1' ) ),
+				'syringeUnits' => 100, // Must match PRC_Math::SYRINGE_UNITS_PER_ML and calculator.js SYRINGE_UNITS_PER_ML.
+				'i18n'         => array(
+					'selectPeptide' => __( 'Select a peptide…', 'peptide-reconstitution-calculator' ),
+					'customEntry'   => __( 'Custom / Manual Entry', 'peptide-reconstitution-calculator' ),
+					'calculate'     => __( 'Calculate', 'peptide-reconstitution-calculator' ),
+					'reset'         => __( 'Reset', 'peptide-reconstitution-calculator' ),
+					'concentration' => __( 'Concentration', 'peptide-reconstitution-calculator' ),
+					'injectionVol'  => __( 'Injection Volume', 'peptide-reconstitution-calculator' ),
+					'syringeUnits'  => __( 'Syringe Units', 'peptide-reconstitution-calculator' ),
+					'dosesPerVial'  => __( 'Doses Per Vial', 'peptide-reconstitution-calculator' ),
+					'perUnit'       => __( 'per unit', 'peptide-reconstitution-calculator' ),
+					'disclaimer'    => __( 'For informational purposes only. Not medical advice. Always consult a qualified healthcare professional.', 'peptide-reconstitution-calculator' ),
+				),
+			)
+		);
 
 		$this->assets_enqueued = true;
 	}
@@ -155,7 +159,7 @@ class PRC_Shortcode {
 						<select id="prc-vial-select" class="prc-field__input prc-field__input--half"></select>
 						<div class="prc-field__custom-wrap">
 							<input type="number" id="prc-vial-mg" class="prc-field__input prc-field__input--half"
-								   step="0.1" min="0.1" placeholder="5" />
+									step="0.1" min="0.1" placeholder="5" />
 							<span class="prc-field__unit"><?php esc_html_e( 'mg', 'peptide-reconstitution-calculator' ); ?></span>
 						</div>
 					</div>
@@ -168,7 +172,7 @@ class PRC_Shortcode {
 					</label>
 					<div class="prc-field__row">
 						<input type="number" id="prc-water-ml" class="prc-field__input"
-							   step="0.1" min="0.1" placeholder="2.0" />
+								step="0.1" min="0.1" placeholder="2.0" />
 						<span class="prc-field__unit"><?php esc_html_e( 'mL', 'peptide-reconstitution-calculator' ); ?></span>
 					</div>
 				</div>
@@ -180,7 +184,7 @@ class PRC_Shortcode {
 					</label>
 					<div class="prc-field__row">
 						<input type="number" id="prc-desired-dose" class="prc-field__input"
-							   step="any" min="0" placeholder="250" />
+								step="any" min="0" placeholder="250" />
 						<select id="prc-dose-unit" class="prc-field__input prc-field__input--unit">
 							<option value="mcg">mcg</option>
 							<option value="mg">mg</option>

--- a/includes/frontend/class-prc-shortcode.php
+++ b/includes/frontend/class-prc-shortcode.php
@@ -10,6 +10,7 @@
  * @see assets/js/calculator.js  — Client-side calculator logic.
  * @see assets/css/calculator.css — Calculator styles.
  * @see class-prc-calculator.php  — Boot orchestrator.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "peptide-reconstitution-calculator",
+  "version": "1.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "peptide-reconstitution-calculator",
+      "version": "1.2.0",
+      "license": "GPL-2.0-or-later"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "peptide-reconstitution-calculator",
+  "version": "1.2.0",
+  "description": "Reconstitution calculator WordPress plugin — JS asset package config.",
+  "private": true,
+  "scripts": {
+    "lint": "node --check assets/js/calculator.js"
+  }
+}

--- a/peptide-reconstitution-calculator.php
+++ b/peptide-reconstitution-calculator.php
@@ -3,7 +3,7 @@
  * Plugin Name: Peptide Reconstitution Calculator
  * Plugin URI:  https://peptiderepo.com/tools/reconstitution-calculator
  * Description: Interactive reconstitution calculator with peptide-specific presets from Peptide Repo Core. Computes concentration, injection volume, syringe units, and doses per vial.
- * Version:     1.0.0
+ * Version:     1.2.0
  * Author:      peptiderepo
  * Author URI:  https://peptiderepo.com
  * License:     GPL-2.0-or-later
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /* ── Constants ────────────────────────────────────────────────────────── */
 
-define( 'PRC_VERSION', '1.0.0' );
+define( 'PRC_VERSION', '1.2.0' );
 define( 'PRC_PLUGIN_FILE', __FILE__ );
 define( 'PRC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'PRC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );

--- a/peptide-reconstitution-calculator.php
+++ b/peptide-reconstitution-calculator.php
@@ -15,6 +15,7 @@
  *
  * Depends on: Peptide Repo Core (optional — provides peptide-specific presets).
  * Without PR Core, the calculator still works with manual entry and built-in defaults.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);

--- a/peptide-reconstitution-calculator.php
+++ b/peptide-reconstitution-calculator.php
@@ -37,9 +37,9 @@ PRC_Autoloader::register();
 
 /* ── Activation / Deactivation ────────────────────────────────────────── */
 
-register_activation_hook( __FILE__, [ 'PRC_Activator', 'activate' ] );
-register_deactivation_hook( __FILE__, [ 'PRC_Deactivator', 'deactivate' ] );
+register_activation_hook( __FILE__, array( 'PRC_Activator', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'PRC_Deactivator', 'deactivate' ) );
 
 /* ── Boot ─────────────────────────────────────────────────────────────── */
 
-add_action( 'plugins_loaded', [ 'PRC_Calculator', 'boot' ] );
+add_action( 'plugins_loaded', array( 'PRC_Calculator', 'boot' ) );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    backupGlobals="false"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory suffix="Test.php">./tests/unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./includes</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,331 @@
+<?php
+/**
+ * PHPUnit bootstrap for Peptide Reconstitution Calculator tests.
+ *
+ * Loads WordPress stubs so unit tests can reference WP functions and classes
+ * without requiring a full WordPress installation. All stubs are minimal
+ * no-ops sufficient for the tested surface area.
+ *
+ * @package PRC\Tests
+ */
+
+// Composer autoloader.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
+
+// ── WordPress constant stubs ──────────────────────────────────────────
+
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/wordpress/' );
+}
+if ( ! defined( 'WPINC' ) ) {
+	define( 'WPINC', 'wp-includes' );
+}
+
+// Plugin constants normally defined in the main bootstrap file.
+if ( ! defined( 'PRC_VERSION' ) ) {
+	define( 'PRC_VERSION', '1.2.0-test' );
+}
+if ( ! defined( 'PRC_PLUGIN_FILE' ) ) {
+	define( 'PRC_PLUGIN_FILE', dirname( __DIR__ ) . '/peptide-reconstitution-calculator.php' );
+}
+if ( ! defined( 'PRC_PLUGIN_DIR' ) ) {
+	define( 'PRC_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
+}
+if ( ! defined( 'PRC_PLUGIN_URL' ) ) {
+	define( 'PRC_PLUGIN_URL', 'https://example.com/wp-content/plugins/peptide-reconstitution-calculator/' );
+}
+
+// ── WordPress function stubs ──────────────────────────────────────────
+
+if ( ! function_exists( 'plugin_dir_path' ) ) {
+	function plugin_dir_path( $file ) {
+		return trailingslashit( dirname( $file ) );
+	}
+}
+if ( ! function_exists( 'plugin_dir_url' ) ) {
+	function plugin_dir_url( $file ) {
+		return 'https://example.com/wp-content/plugins/' . basename( dirname( $file ) ) . '/';
+	}
+}
+if ( ! function_exists( 'plugin_basename' ) ) {
+	function plugin_basename( $file ) {
+		return basename( dirname( $file ) ) . '/' . basename( $file );
+	}
+}
+if ( ! function_exists( 'trailingslashit' ) ) {
+	function trailingslashit( $string ) {
+		return rtrim( $string, '/\\' ) . '/';
+	}
+}
+if ( ! function_exists( 'sanitize_text_field' ) ) {
+	function sanitize_text_field( $str ) {
+		return trim( strip_tags( $str ) );
+	}
+}
+if ( ! function_exists( 'sanitize_title' ) ) {
+	function sanitize_title( $title, $fallback_title = '', $context = 'save' ) {
+		$title = strip_tags( $title );
+		$title = strtolower( $title );
+		$title = preg_replace( '/[^a-z0-9\-]/', '-', $title );
+		$title = preg_replace( '/-+/', '-', $title );
+		return trim( $title, '-' );
+	}
+}
+if ( ! function_exists( 'absint' ) ) {
+	function absint( $val ) {
+		return abs( (int) $val );
+	}
+}
+if ( ! function_exists( 'add_action' ) ) {
+	function add_action( $tag, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $tag, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'add_shortcode' ) ) {
+	function add_shortcode( $tag, $callback ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'shortcode_atts' ) ) {
+	function shortcode_atts( $pairs, $atts, $shortcode = '' ) {
+		$atts = (array) $atts;
+		$out  = array();
+		foreach ( $pairs as $name => $default ) {
+			$out[ $name ] = array_key_exists( $name, $atts ) ? $atts[ $name ] : $default;
+		}
+		return $out;
+	}
+}
+if ( ! function_exists( 'register_rest_route' ) ) {
+	function register_rest_route( $namespace, $route, $args = array(), $override = false ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'rest_url' ) ) {
+	function rest_url( $path = '' ) {
+		return 'https://example.com/wp-json/' . ltrim( $path, '/' );
+	}
+}
+if ( ! function_exists( 'esc_url_raw' ) ) {
+	function esc_url_raw( $url, $protocols = null ) {
+		return filter_var( $url, FILTER_SANITIZE_URL ) ?: '';
+	}
+}
+if ( ! function_exists( 'esc_attr' ) ) {
+	function esc_attr( $text ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'esc_html' ) ) {
+	function esc_html( $text ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'esc_html__' ) ) {
+	function esc_html__( $text, $domain = 'default' ) {
+		return htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+if ( ! function_exists( 'esc_html_e' ) ) {
+	function esc_html_e( $text, $domain = 'default' ) {
+		echo htmlspecialchars( $text, ENT_QUOTES, 'UTF-8' );
+	}
+}
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+if ( ! function_exists( 'is_admin' ) ) {
+	function is_admin() {
+		global $_test_is_admin;
+		return ! empty( $_test_is_admin );
+	}
+}
+if ( ! function_exists( 'wp_enqueue_style' ) ) {
+	function wp_enqueue_style( $handle, $src = '', $deps = array(), $ver = false, $media = 'all' ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'wp_enqueue_script' ) ) {
+	function wp_enqueue_script( $handle, $src = '', $deps = array(), $ver = false, $args = array() ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'wp_localize_script' ) ) {
+	function wp_localize_script( $handle, $object_name, $l10n ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'get_transient' ) ) {
+	function get_transient( $transient ) {
+		global $_test_transients;
+		return isset( $_test_transients[ $transient ] ) ? $_test_transients[ $transient ] : false;
+	}
+}
+if ( ! function_exists( 'set_transient' ) ) {
+	function set_transient( $transient, $value, $expiration = 0 ) {
+		global $_test_transients;
+		$_test_transients[ $transient ] = $value;
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_transient' ) ) {
+	function delete_transient( $transient ) {
+		global $_test_transients;
+		unset( $_test_transients[ $transient ] );
+		return true;
+	}
+}
+if ( ! function_exists( 'register_activation_hook' ) ) {
+	function register_activation_hook( $file, $callback ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'register_deactivation_hook' ) ) {
+	function register_deactivation_hook( $file, $callback ) {
+		return true;
+	}
+}
+if ( ! function_exists( 'delete_option' ) ) {
+	function delete_option( $option ) {
+		global $_test_options;
+		unset( $_test_options[ $option ] );
+		return true;
+	}
+}
+if ( ! function_exists( 'wp_cache_flush' ) ) {
+	function wp_cache_flush() {
+		return true;
+	}
+}
+if ( ! function_exists( 'get_option' ) ) {
+	function get_option( $option, $default = false ) {
+		global $_test_options;
+		return isset( $_test_options[ $option ] ) ? $_test_options[ $option ] : $default;
+	}
+}
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $tag, ...$args ) {
+		return null;
+	}
+}
+
+// WP_REST_Request stub used by REST controller tests.
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request {
+		/** @var array<string, mixed> */
+		private array $params = array();
+		private string $method;
+
+		public function __construct( string $method = 'GET', string $route = '' ) {
+			$this->method = $method;
+		}
+
+		/**
+		 * @param string $key
+		 * @param mixed  $value
+		 */
+		public function set_param( string $key, $value ): void {
+			$this->params[ $key ] = $value;
+		}
+
+		/**
+		 * @param string $key
+		 * @return mixed
+		 */
+		public function get_param( string $key ) {
+			return $this->params[ $key ] ?? null;
+		}
+
+		/** @return array<string, mixed> */
+		public function get_params(): array {
+			return $this->params;
+		}
+	}
+}
+
+// WP_REST_Response stub.
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		/** @var mixed */
+		public $data;
+		public int $status;
+
+		/**
+		 * @param mixed $data
+		 */
+		public function __construct( $data = null, int $status = 200 ) {
+			$this->data   = $data;
+			$this->status = $status;
+		}
+
+		/** @return mixed */
+		public function get_data() {
+			return $this->data;
+		}
+
+		public function get_status(): int {
+			return $this->status;
+		}
+	}
+}
+
+// WP_Error stub.
+if ( ! class_exists( 'WP_Error' ) ) {
+	class WP_Error {
+		/** @var array<string, string[]> */
+		public array $errors = array();
+		/** @var array<string, mixed> */
+		public array $error_data = array();
+
+		/**
+		 * @param mixed $data
+		 */
+		public function __construct( string $code = '', string $message = '', $data = '' ) {
+			if ( $code ) {
+				$this->errors[ $code ][] = $message;
+				if ( $data ) {
+					$this->error_data[ $code ] = $data;
+				}
+			}
+		}
+
+		public function get_error_code(): string {
+			$codes = array_keys( $this->errors );
+			return $codes ? $codes[0] : '';
+		}
+
+		public function get_error_message( string $code = '' ): string {
+			if ( ! $code ) {
+				$code = $this->get_error_code();
+			}
+			return isset( $this->errors[ $code ] ) ? $this->errors[ $code ][0] : '';
+		}
+	}
+}
+
+if ( ! function_exists( 'is_wp_error' ) ) {
+	function is_wp_error( $thing ): bool {
+		return ( $thing instanceof WP_Error );
+	}
+}
+
+// ── Load plugin classes for testing ──────────────────────────────────
+
+// The autoloader resolves PRC_ classes from includes/ — register it now.
+require_once PRC_PLUGIN_DIR . 'includes/class-prc-autoloader.php';
+PRC_Autoloader::register();
+
+// Load pure classes explicitly (no WP hooks fire at require time).
+require_once PRC_PLUGIN_DIR . 'includes/class-prc-math.php';
+require_once PRC_PLUGIN_DIR . 'includes/class-prc-default-presets.php';
+require_once PRC_PLUGIN_DIR . 'includes/class-prc-calculator.php';
+require_once PRC_PLUGIN_DIR . 'includes/class-prc-preset-provider.php';
+require_once PRC_PLUGIN_DIR . 'includes/api/class-prc-rest-controller.php';
+require_once PRC_PLUGIN_DIR . 'includes/frontend/class-prc-shortcode.php';

--- a/tests/unit/DefaultPresetsTest.php
+++ b/tests/unit/DefaultPresetsTest.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Unit tests for PRC_Default_Presets.
+ *
+ * Verifies that the hardcoded fallback preset list is well-formed:
+ * expected slugs are present, required keys exist, numeric ranges
+ * are sensible, and no data has been accidentally corrupted.
+ *
+ * @package PRC\Tests\Unit
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PRC_Default_Presets::get_all().
+ */
+class DefaultPresetsTest extends TestCase {
+
+	/** @var array<int, array<string, mixed>> */
+	private array $presets;
+
+	protected function setUp(): void {
+		$this->presets = PRC_Default_Presets::get_all();
+	}
+
+	// ── Collection shape ──────────────────────────────────────────────
+
+	/**
+	 * get_all() returns an array with at least one entry.
+	 */
+	public function test_get_all_returns_array(): void {
+		$this->assertIsArray( $this->presets );
+		$this->assertGreaterThanOrEqual( 1, count( $this->presets ) );
+	}
+
+	/**
+	 * Exactly 8 built-in presets are defined.
+	 */
+	public function test_get_all_contains_eight_presets(): void {
+		$this->assertCount( 8, $this->presets );
+	}
+
+	/**
+	 * The 8 expected slugs are all present.
+	 */
+	public function test_expected_slugs_present(): void {
+		$slugs = array_column( $this->presets, 'slug' );
+
+		$expected = [
+			'bpc-157',
+			'tb-500',
+			'semaglutide',
+			'cjc-1295-dac',
+			'ipamorelin',
+			'pt-141',
+			'mk-677',
+			'ghrp-6',
+		];
+
+		foreach ( $expected as $slug ) {
+			$this->assertContains( $slug, $slugs, "Missing expected slug: $slug" );
+		}
+	}
+
+	// ── Per-preset required fields ────────────────────────────────────
+
+	/**
+	 * Every preset has all required keys.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_has_required_keys( array $preset ): void {
+		$required = [
+			'slug',
+			'name',
+			'vial_sizes_mg',
+			'default_vial_mg',
+			'recommended_water_ml',
+			'dose_range_min',
+			'dose_range_max',
+			'dose_unit',
+			'typical_frequency',
+			'evidence_strength',
+			'source',
+		];
+
+		foreach ( $required as $key ) {
+			$this->assertArrayHasKey( $key, $preset, "Missing key '$key' in preset '{$preset['slug']}'" );
+		}
+	}
+
+	/**
+	 * Every preset's slug is a non-empty string.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_slug_is_non_empty_string( array $preset ): void {
+		$this->assertIsString( $preset['slug'] );
+		$this->assertNotEmpty( $preset['slug'] );
+	}
+
+	/**
+	 * Every preset's name is a non-empty string.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_name_is_non_empty_string( array $preset ): void {
+		$this->assertIsString( $preset['name'] );
+		$this->assertNotEmpty( $preset['name'] );
+	}
+
+	/**
+	 * vial_sizes_mg is a non-empty array of positive floats.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_vial_sizes_are_positive( array $preset ): void {
+		$this->assertIsArray( $preset['vial_sizes_mg'] );
+		$this->assertNotEmpty( $preset['vial_sizes_mg'] );
+
+		foreach ( $preset['vial_sizes_mg'] as $size ) {
+			$this->assertIsNumeric( $size );
+			$this->assertGreaterThan( 0, $size, "Non-positive vial size in preset '{$preset['slug']}'" );
+		}
+	}
+
+	/**
+	 * default_vial_mg is one of the values in vial_sizes_mg.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_default_vial_is_in_sizes( array $preset ): void {
+		$this->assertContains(
+			$preset['default_vial_mg'],
+			$preset['vial_sizes_mg'],
+			"default_vial_mg not in vial_sizes_mg for preset '{$preset['slug']}'"
+		);
+	}
+
+	/**
+	 * recommended_water_ml is positive.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_recommended_water_is_positive( array $preset ): void {
+		$this->assertGreaterThan( 0, $preset['recommended_water_ml'] );
+	}
+
+	/**
+	 * dose_unit is either 'mcg' or 'mg'.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_dose_unit_is_valid( array $preset ): void {
+		$this->assertContains( $preset['dose_unit'], [ 'mcg', 'mg' ], "Invalid dose_unit in preset '{$preset['slug']}'" );
+	}
+
+	/**
+	 * dose_range_min < dose_range_max when both are non-null.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_dose_range_min_less_than_max( array $preset ): void {
+		if ( null === $preset['dose_range_min'] || null === $preset['dose_range_max'] ) {
+			$this->addToAssertionCount( 1 ); // Null ranges are acceptable.
+			return;
+		}
+
+		$this->assertLessThan(
+			$preset['dose_range_max'],
+			$preset['dose_range_min'],
+			"dose_range_min >= dose_range_max in preset '{$preset['slug']}'"
+		);
+	}
+
+	/**
+	 * source field is 'default' for every built-in preset.
+	 *
+	 * @dataProvider preset_provider
+	 * @param array<string, mixed> $preset
+	 */
+	public function test_preset_source_is_default( array $preset ): void {
+		$this->assertSame( 'default', $preset['source'] );
+	}
+
+	// ── Spot-check specific known values ──────────────────────────────
+
+	/**
+	 * BPC-157: 5 mg default vial, 2 mL water, 500 mcg max dose.
+	 */
+	public function test_bpc157_specific_values(): void {
+		$preset = $this->find_preset( 'bpc-157' );
+
+		$this->assertNotNull( $preset );
+		$this->assertSame( 5.0, (float) $preset['default_vial_mg'] );
+		$this->assertSame( 2.0, (float) $preset['recommended_water_ml'] );
+		$this->assertSame( 500.0, (float) $preset['dose_range_max'] );
+		$this->assertSame( 'mcg', $preset['dose_unit'] );
+	}
+
+	/**
+	 * Semaglutide: dose_unit is mg (not mcg), max dose 2.4 mg.
+	 */
+	public function test_semaglutide_mg_dose_unit(): void {
+		$preset = $this->find_preset( 'semaglutide' );
+
+		$this->assertNotNull( $preset );
+		$this->assertSame( 'mg', $preset['dose_unit'] );
+		$this->assertEqualsWithDelta( 2.4, (float) $preset['dose_range_max'], 0.01 );
+	}
+
+	/**
+	 * MK-677: 30 mg default vial, 3 mL water (large-vial path in recommend_water_ml).
+	 */
+	public function test_mk677_large_vial_water_recommendation(): void {
+		$preset = $this->find_preset( 'mk-677' );
+
+		$this->assertNotNull( $preset );
+		$this->assertSame( 30.0, (float) $preset['default_vial_mg'] );
+		$this->assertSame( 3.0, (float) $preset['recommended_water_ml'] );
+	}
+
+	// ── DataProvider ──────────────────────────────────────────────────
+
+	/**
+	 * Provides each preset individually.
+	 *
+	 * @return array<string, array{array<string, mixed>}>
+	 */
+	public function preset_provider(): array {
+		$presets = PRC_Default_Presets::get_all();
+		$cases   = [];
+		foreach ( $presets as $preset ) {
+			$cases[ $preset['slug'] ] = [ $preset ];
+		}
+		return $cases;
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────
+
+	/**
+	 * Find a preset by slug.
+	 *
+	 * @param string $slug
+	 * @return array<string, mixed>|null
+	 */
+	private function find_preset( string $slug ): ?array {
+		foreach ( $this->presets as $preset ) {
+			if ( $preset['slug'] === $slug ) {
+				return $preset;
+			}
+		}
+		return null;
+	}
+}

--- a/tests/unit/MathTest.php
+++ b/tests/unit/MathTest.php
@@ -1,0 +1,444 @@
+<?php
+/**
+ * Unit tests for PRC_Math — the pure reconstitution calculation engine.
+ *
+ * Covers the full public API of PRC_Math: concentration, injection volume,
+ * syringe units, doses per vial, and the top-level calculate() orchestrator.
+ * All expected values were computed manually from the formulas in class-prc-math.php.
+ *
+ * Math reference:
+ *   concentration_mg_per_ml = vial_mg / water_ml
+ *   concentration_mcg_per_unit = (vial_mg * 1000) / (water_ml * 100)
+ *   injection_volume_ml = dose_mg / concentration_mg_per_ml
+ *   syringe_units = injection_volume_ml * 100
+ *   doses_per_vial = vial_mg / dose_mg  (floor in calculate())
+ *
+ * @package PRC\Tests\Unit
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PRC_Math static methods.
+ */
+class MathTest extends TestCase {
+
+	// ── concentration_mg_per_ml ───────────────────────────────────────
+
+	/**
+	 * Standard BPC-157 vial: 5 mg peptide in 2 mL water → 2.5 mg/mL.
+	 */
+	public function test_concentration_mg_per_ml_standard(): void {
+		$result = PRC_Math::concentration_mg_per_ml( 5.0, 2.0 );
+		$this->assertEqualsWithDelta( 2.5, $result, 0.0001 );
+	}
+
+	/**
+	 * 10 mg peptide in 2 mL water → 5.0 mg/mL.
+	 */
+	public function test_concentration_mg_per_ml_high_dose(): void {
+		$result = PRC_Math::concentration_mg_per_ml( 10.0, 2.0 );
+		$this->assertEqualsWithDelta( 5.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 2 mg peptide in 1 mL water → 2.0 mg/mL.
+	 */
+	public function test_concentration_mg_per_ml_small_vial(): void {
+		$result = PRC_Math::concentration_mg_per_ml( 2.0, 1.0 );
+		$this->assertEqualsWithDelta( 2.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 30 mg peptide in 3 mL water → 10.0 mg/mL.
+	 */
+	public function test_concentration_mg_per_ml_large_vial(): void {
+		$result = PRC_Math::concentration_mg_per_ml( 30.0, 3.0 );
+		$this->assertEqualsWithDelta( 10.0, $result, 0.0001 );
+	}
+
+	/**
+	 * Zero water volume → returns 0 (division guard).
+	 */
+	public function test_concentration_mg_per_ml_zero_water_returns_zero(): void {
+		$result = PRC_Math::concentration_mg_per_ml( 5.0, 0.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	/**
+	 * Negative water volume is treated as zero (guard condition uses <=).
+	 */
+	public function test_concentration_mg_per_ml_negative_water_returns_zero(): void {
+		$result = PRC_Math::concentration_mg_per_ml( 5.0, -1.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	/**
+	 * Zero vial mg with valid water → 0 mg/mL.
+	 */
+	public function test_concentration_mg_per_ml_zero_peptide(): void {
+		$result = PRC_Math::concentration_mg_per_ml( 0.0, 2.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	// ── concentration_mcg_per_unit ────────────────────────────────────
+
+	/**
+	 * 5 mg / 2 mL: (5 * 1000) / (2 * 100) = 5000 / 200 = 25.0 mcg/unit.
+	 */
+	public function test_concentration_mcg_per_unit_standard(): void {
+		$result = PRC_Math::concentration_mcg_per_unit( 5.0, 2.0 );
+		$this->assertEqualsWithDelta( 25.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 10 mg / 2 mL: (10 * 1000) / (2 * 100) = 10000 / 200 = 50.0 mcg/unit.
+	 */
+	public function test_concentration_mcg_per_unit_10mg_2ml(): void {
+		$result = PRC_Math::concentration_mcg_per_unit( 10.0, 2.0 );
+		$this->assertEqualsWithDelta( 50.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 2 mg / 1 mL: (2 * 1000) / (1 * 100) = 2000 / 100 = 20.0 mcg/unit.
+	 */
+	public function test_concentration_mcg_per_unit_2mg_1ml(): void {
+		$result = PRC_Math::concentration_mcg_per_unit( 2.0, 1.0 );
+		$this->assertEqualsWithDelta( 20.0, $result, 0.0001 );
+	}
+
+	/**
+	 * Zero water → returns 0 (guard).
+	 */
+	public function test_concentration_mcg_per_unit_zero_water_returns_zero(): void {
+		$result = PRC_Math::concentration_mcg_per_unit( 5.0, 0.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	// ── injection_volume_ml ───────────────────────────────────────────
+
+	/**
+	 * 250 mcg dose at 2.5 mg/mL: dose_mg = 0.25 → 0.25 / 2.5 = 0.1 mL.
+	 */
+	public function test_injection_volume_ml_standard(): void {
+		$result = PRC_Math::injection_volume_ml( 0.25, 2.5 );
+		$this->assertEqualsWithDelta( 0.1, $result, 0.0001 );
+	}
+
+	/**
+	 * 500 mcg dose at 2.5 mg/mL: 0.5 / 2.5 = 0.2 mL.
+	 */
+	public function test_injection_volume_ml_higher_dose(): void {
+		$result = PRC_Math::injection_volume_ml( 0.5, 2.5 );
+		$this->assertEqualsWithDelta( 0.2, $result, 0.0001 );
+	}
+
+	/**
+	 * 1 mg dose at 5 mg/mL: 1.0 / 5.0 = 0.2 mL.
+	 */
+	public function test_injection_volume_ml_mg_dose(): void {
+		$result = PRC_Math::injection_volume_ml( 1.0, 5.0 );
+		$this->assertEqualsWithDelta( 0.2, $result, 0.0001 );
+	}
+
+	/**
+	 * Zero concentration → returns 0 (division guard).
+	 */
+	public function test_injection_volume_ml_zero_concentration_returns_zero(): void {
+		$result = PRC_Math::injection_volume_ml( 0.25, 0.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	/**
+	 * Negative concentration → returns 0 (guard condition uses <=).
+	 */
+	public function test_injection_volume_ml_negative_concentration_returns_zero(): void {
+		$result = PRC_Math::injection_volume_ml( 0.25, -1.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	// ── syringe_units ─────────────────────────────────────────────────
+
+	/**
+	 * 0.1 mL × 100 = 10 units.
+	 */
+	public function test_syringe_units_0_1_ml(): void {
+		$result = PRC_Math::syringe_units( 0.1 );
+		$this->assertEqualsWithDelta( 10.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 0.2 mL × 100 = 20 units.
+	 */
+	public function test_syringe_units_0_2_ml(): void {
+		$result = PRC_Math::syringe_units( 0.2 );
+		$this->assertEqualsWithDelta( 20.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 1 mL × 100 = 100 units (full syringe).
+	 */
+	public function test_syringe_units_full_ml(): void {
+		$result = PRC_Math::syringe_units( 1.0 );
+		$this->assertEqualsWithDelta( 100.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 0 mL → 0 units.
+	 */
+	public function test_syringe_units_zero(): void {
+		$result = PRC_Math::syringe_units( 0.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	/**
+	 * Fractional: 0.05 mL × 100 = 5.0 units.
+	 */
+	public function test_syringe_units_fractional(): void {
+		$result = PRC_Math::syringe_units( 0.05 );
+		$this->assertEqualsWithDelta( 5.0, $result, 0.0001 );
+	}
+
+	// ── doses_per_vial ────────────────────────────────────────────────
+
+	/**
+	 * 5 mg vial at 0.25 mg dose → 20 doses.
+	 */
+	public function test_doses_per_vial_standard(): void {
+		$result = PRC_Math::doses_per_vial( 5.0, 0.25 );
+		$this->assertEqualsWithDelta( 20.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 10 mg vial at 0.5 mg dose → 20 doses.
+	 */
+	public function test_doses_per_vial_large_vial(): void {
+		$result = PRC_Math::doses_per_vial( 10.0, 0.5 );
+		$this->assertEqualsWithDelta( 20.0, $result, 0.0001 );
+	}
+
+	/**
+	 * 5 mg vial at 0.3 mg dose → 16.666... (floor returns 16 in calculate()).
+	 */
+	public function test_doses_per_vial_non_integer(): void {
+		$result = PRC_Math::doses_per_vial( 5.0, 0.3 );
+		// Raw float — floor applied in calculate().
+		$this->assertGreaterThan( 16.0, $result );
+		$this->assertLessThan( 17.0, $result );
+	}
+
+	/**
+	 * Zero dose → returns 0 (guard against division by zero).
+	 */
+	public function test_doses_per_vial_zero_dose_returns_zero(): void {
+		$result = PRC_Math::doses_per_vial( 5.0, 0.0 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	/**
+	 * Negative dose → returns 0 (guard condition uses <=).
+	 */
+	public function test_doses_per_vial_negative_dose_returns_zero(): void {
+		$result = PRC_Math::doses_per_vial( 5.0, -0.25 );
+		$this->assertSame( 0.0, $result );
+	}
+
+	// ── calculate() — full orchestrator ──────────────────────────────
+
+	/**
+	 * BPC-157 typical scenario: 5 mg vial, 2 mL BAC water, 250 mcg dose.
+	 *
+	 * Expected:
+	 *   concentration_mg_per_ml    = 5 / 2 = 2.5
+	 *   concentration_mcg_per_unit = (5000) / (200) = 25.0
+	 *   injection_volume_ml        = 0.25 / 2.5 = 0.1
+	 *   syringe_units              = 0.1 * 100 = 10
+	 *   doses_per_vial             = floor(5 / 0.25) = 20
+	 */
+	public function test_calculate_bpc157_250mcg_dose(): void {
+		$result = PRC_Math::calculate( 5.0, 2.0, 250.0, 'mcg' );
+
+		$this->assertIsArray( $result );
+		$this->assertEqualsWithDelta( 2.5, $result['concentration_mg_per_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 25.0, $result['concentration_mcg_per_unit'], 0.01 );
+		$this->assertEqualsWithDelta( 0.1, $result['injection_volume_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 10.0, $result['syringe_units'], 0.1 );
+		$this->assertSame( 20.0, $result['doses_per_vial'] );
+		$this->assertSame( 5.0, $result['total_peptide_mg'] );
+		$this->assertSame( 2.0, $result['water_ml'] );
+		$this->assertEqualsWithDelta( 0.25, $result['desired_dose_mg'], 0.0001 );
+		$this->assertSame( 250.0, $result['desired_dose_display'] );
+		$this->assertSame( 'mcg', $result['dose_unit'] );
+	}
+
+	/**
+	 * Semaglutide scenario: 5 mg vial, 2 mL BAC water, 0.5 mg dose (mg unit).
+	 *
+	 * Expected:
+	 *   concentration_mg_per_ml    = 5 / 2 = 2.5
+	 *   concentration_mcg_per_unit = 25.0
+	 *   injection_volume_ml        = 0.5 / 2.5 = 0.2
+	 *   syringe_units              = 0.2 * 100 = 20
+	 *   doses_per_vial             = floor(5 / 0.5) = 10
+	 */
+	public function test_calculate_semaglutide_0_5mg_dose(): void {
+		$result = PRC_Math::calculate( 5.0, 2.0, 0.5, 'mg' );
+
+		$this->assertEqualsWithDelta( 2.5, $result['concentration_mg_per_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 25.0, $result['concentration_mcg_per_unit'], 0.01 );
+		$this->assertEqualsWithDelta( 0.2, $result['injection_volume_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 20.0, $result['syringe_units'], 0.1 );
+		$this->assertSame( 10.0, $result['doses_per_vial'] );
+		$this->assertSame( 'mg', $result['dose_unit'] );
+	}
+
+	/**
+	 * TB-500 high-dose scenario: 10 mg vial, 2 mL water, 2000 mcg dose.
+	 *
+	 * Expected:
+	 *   concentration_mg_per_ml    = 10 / 2 = 5.0
+	 *   concentration_mcg_per_unit = (10000) / (200) = 50.0
+	 *   injection_volume_ml        = 2.0 / 5.0 = 0.4
+	 *   syringe_units              = 0.4 * 100 = 40
+	 *   doses_per_vial             = floor(10 / 2) = 5
+	 */
+	public function test_calculate_tb500_2000mcg_dose(): void {
+		$result = PRC_Math::calculate( 10.0, 2.0, 2000.0, 'mcg' );
+
+		$this->assertEqualsWithDelta( 5.0, $result['concentration_mg_per_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 50.0, $result['concentration_mcg_per_unit'], 0.01 );
+		$this->assertEqualsWithDelta( 0.4, $result['injection_volume_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 40.0, $result['syringe_units'], 0.1 );
+		$this->assertSame( 5.0, $result['doses_per_vial'] );
+	}
+
+	/**
+	 * MK-677 mg-dose scenario: 30 mg vial, 3 mL water, 25 mg dose.
+	 *
+	 * Expected:
+	 *   concentration_mg_per_ml    = 30 / 3 = 10.0
+	 *   concentration_mcg_per_unit = (30000) / (300) = 100.0
+	 *   injection_volume_ml        = 25 / 10 = 2.5
+	 *   syringe_units              = 2.5 * 100 = 250
+	 *   doses_per_vial             = floor(30 / 25) = 1
+	 */
+	public function test_calculate_mk677_25mg_dose(): void {
+		$result = PRC_Math::calculate( 30.0, 3.0, 25.0, 'mg' );
+
+		$this->assertEqualsWithDelta( 10.0, $result['concentration_mg_per_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 100.0, $result['concentration_mcg_per_unit'], 0.01 );
+		$this->assertEqualsWithDelta( 2.5, $result['injection_volume_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 250.0, $result['syringe_units'], 0.1 );
+		$this->assertSame( 1.0, $result['doses_per_vial'] );
+	}
+
+	/**
+	 * Minimum BPC-157 dose: 200 mcg from a 5 mg / 2 mL vial.
+	 *
+	 * Expected:
+	 *   injection_volume_ml = 0.2 / 2.5 = 0.08
+	 *   syringe_units       = 0.08 * 100 = 8.0
+	 *   doses_per_vial      = floor(5 / 0.2) = 25
+	 */
+	public function test_calculate_bpc157_200mcg_minimum_dose(): void {
+		$result = PRC_Math::calculate( 5.0, 2.0, 200.0, 'mcg' );
+
+		$this->assertEqualsWithDelta( 0.08, $result['injection_volume_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 8.0, $result['syringe_units'], 0.1 );
+		$this->assertSame( 25.0, $result['doses_per_vial'] );
+	}
+
+	/**
+	 * Very small dose: 100 mcg from 5 mg / 2 mL.
+	 *
+	 * Expected:
+	 *   injection_volume_ml = 0.1 / 2.5 = 0.04
+	 *   syringe_units       = 4.0
+	 *   doses_per_vial      = floor(5 / 0.1) = 50
+	 */
+	public function test_calculate_ipamorelin_100mcg_dose(): void {
+		$result = PRC_Math::calculate( 5.0, 2.0, 100.0, 'mcg' );
+
+		$this->assertEqualsWithDelta( 0.04, $result['injection_volume_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 4.0, $result['syringe_units'], 0.1 );
+		$this->assertSame( 50.0, $result['doses_per_vial'] );
+	}
+
+	/**
+	 * Non-integer doses-per-vial: 5 mg vial, 300 mcg dose → 16.666 → floor → 16.
+	 */
+	public function test_calculate_doses_per_vial_is_floored(): void {
+		$result = PRC_Math::calculate( 5.0, 2.0, 300.0, 'mcg' );
+
+		$this->assertSame( 16.0, $result['doses_per_vial'] );
+	}
+
+	/**
+	 * mcg/unit output is rounded to 2 decimal places.
+	 */
+	public function test_calculate_concentration_mcg_per_unit_rounded_to_two_decimals(): void {
+		// 3 mg / 2 mL: mcg_per_unit = 3000 / 200 = 15.0 — exact, check rounding still works.
+		$result = PRC_Math::calculate( 3.0, 2.0, 150.0, 'mcg' );
+		// 15.0 rounded to 2 dp = 15.0.
+		$this->assertEqualsWithDelta( 15.0, $result['concentration_mcg_per_unit'], 0.005 );
+	}
+
+	/**
+	 * concentration_mg_per_ml output is rounded to 4 decimal places.
+	 *
+	 * 7 mg / 3 mL = 2.333... → rounded to 4 dp = 2.3333.
+	 */
+	public function test_calculate_concentration_rounded_to_four_decimals(): void {
+		$result = PRC_Math::calculate( 7.0, 3.0, 100.0, 'mcg' );
+		$this->assertEqualsWithDelta( 2.3333, $result['concentration_mg_per_ml'], 0.00005 );
+	}
+
+	/**
+	 * Result array has the expected keys.
+	 */
+	public function test_calculate_returns_expected_keys(): void {
+		$result = PRC_Math::calculate( 5.0, 2.0, 250.0, 'mcg' );
+
+		$expected_keys = [
+			'concentration_mg_per_ml',
+			'concentration_mcg_per_unit',
+			'injection_volume_ml',
+			'syringe_units',
+			'doses_per_vial',
+			'total_peptide_mg',
+			'water_ml',
+			'desired_dose_mg',
+			'desired_dose_display',
+			'dose_unit',
+		];
+
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $result, "Missing key: $key" );
+		}
+	}
+
+	/**
+	 * mcg unit: desired_dose_mg is divided by 1000.
+	 * 500 mcg → 0.5 mg stored as desired_dose_mg.
+	 */
+	public function test_calculate_mcg_dose_unit_conversion(): void {
+		$result = PRC_Math::calculate( 10.0, 2.0, 500.0, 'mcg' );
+
+		$this->assertEqualsWithDelta( 0.5, $result['desired_dose_mg'], 0.0001 );
+		$this->assertSame( 500.0, $result['desired_dose_display'] );
+		$this->assertSame( 'mcg', $result['dose_unit'] );
+	}
+
+	/**
+	 * mg unit: desired_dose_mg equals the raw input value.
+	 */
+	public function test_calculate_mg_dose_unit_no_conversion(): void {
+		$result = PRC_Math::calculate( 10.0, 2.0, 1.5, 'mg' );
+
+		$this->assertEqualsWithDelta( 1.5, $result['desired_dose_mg'], 0.0001 );
+		$this->assertSame( 1.5, $result['desired_dose_display'] );
+		$this->assertSame( 'mg', $result['dose_unit'] );
+	}
+}

--- a/tests/unit/PresetProviderTest.php
+++ b/tests/unit/PresetProviderTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Unit tests for PRC_Preset_Provider (standalone/no-PR-Core path).
+ *
+ * Tests the provider in the state where PR Core is NOT active (no
+ * PR_CORE_VERSION constant), exercising the default-preset fallback,
+ * cache read/write, and cache invalidation.
+ *
+ * @package PRC\Tests\Unit
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PRC_Preset_Provider without PR Core.
+ */
+class PresetProviderTest extends TestCase {
+
+	protected function setUp(): void {
+		// Ensure PR_CORE_VERSION is not defined (test environment default).
+		// The provider checks PRC_Calculator::is_pr_core_active() which checks
+		// defined('PR_CORE_VERSION'). We cannot un-define, so tests assume
+		// the constant is absent (which it is in a clean test run).
+		global $_test_transients;
+		$_test_transients = [];
+	}
+
+	// ── Fallback behavior (no PR Core) ───────────────────────────────
+
+	/**
+	 * get_all_presets() returns a non-empty array when PR Core is absent.
+	 */
+	public function test_get_all_presets_returns_defaults_without_pr_core(): void {
+		$provider = new PRC_Preset_Provider();
+		$presets  = $provider->get_all_presets();
+
+		$this->assertIsArray( $presets );
+		$this->assertGreaterThan( 0, count( $presets ) );
+	}
+
+	/**
+	 * get_all_presets() matches PRC_Default_Presets::get_all() when PR Core absent.
+	 */
+	public function test_get_all_presets_matches_defaults(): void {
+		$provider = new PRC_Preset_Provider();
+		$actual   = $provider->get_all_presets();
+		$expected = PRC_Default_Presets::get_all();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * All returned presets have a slug key.
+	 */
+	public function test_all_presets_have_slug(): void {
+		$provider = new PRC_Preset_Provider();
+		$presets  = $provider->get_all_presets();
+
+		foreach ( $presets as $preset ) {
+			$this->assertArrayHasKey( 'slug', $preset );
+			$this->assertNotEmpty( $preset['slug'] );
+		}
+	}
+
+	// ── Cache invalidation ────────────────────────────────────────────
+
+	/**
+	 * invalidate_cache() removes the 'prc_presets_all' transient.
+	 */
+	public function test_invalidate_cache_removes_transient(): void {
+		global $_test_transients;
+
+		// Seed the transient manually.
+		$_test_transients['prc_presets_all'] = [ 'cached-data' ];
+
+		$provider = new PRC_Preset_Provider();
+		$provider->invalidate_cache();
+
+		$this->assertArrayNotHasKey( 'prc_presets_all', $_test_transients );
+	}
+
+	/**
+	 * Multiple invalidate_cache() calls are safe (idempotent).
+	 */
+	public function test_invalidate_cache_is_idempotent(): void {
+		$provider = new PRC_Preset_Provider();
+
+		// Should not throw, even if transient was never set.
+		$provider->invalidate_cache();
+		$provider->invalidate_cache();
+
+		$this->addToAssertionCount( 1 ); // If we got here, no exception.
+	}
+}

--- a/tests/unit/RestControllerTest.php
+++ b/tests/unit/RestControllerTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Unit tests for PRC_Rest_Controller.
+ *
+ * Tests the calculate() method callback using the WP_REST_Request stub.
+ * The get_presets() / get_preset() methods are thin wrappers over
+ * PRC_Preset_Provider, which is covered by PresetProviderTest.
+ *
+ * @package PRC\Tests\Unit
+ */
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for PRC_Rest_Controller REST callback methods.
+ */
+class RestControllerTest extends TestCase {
+
+	private PRC_Rest_Controller $controller;
+
+	protected function setUp(): void {
+		$this->controller = new PRC_Rest_Controller();
+	}
+
+	// ── /calculate callback ───────────────────────────────────────────
+
+	/**
+	 * calculate() returns a WP_REST_Response with status 200.
+	 */
+	public function test_calculate_returns_200_response(): void {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'vial_mg', '5' );
+		$request->set_param( 'water_ml', '2' );
+		$request->set_param( 'desired_dose', '250' );
+		$request->set_param( 'dose_unit', 'mcg' );
+
+		$response = $this->controller->calculate( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * calculate() returns the correct BPC-157 math results.
+	 *
+	 * 5 mg / 2 mL / 250 mcg → concentration 2.5, syringe units 10.
+	 */
+	public function test_calculate_bpc157_correct_values(): void {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'vial_mg', '5' );
+		$request->set_param( 'water_ml', '2' );
+		$request->set_param( 'desired_dose', '250' );
+		$request->set_param( 'dose_unit', 'mcg' );
+
+		$response = $this->controller->calculate( $request );
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertEqualsWithDelta( 2.5, $data['concentration_mg_per_ml'], 0.0001 );
+		$this->assertEqualsWithDelta( 10.0, $data['syringe_units'], 0.1 );
+		$this->assertSame( 20.0, $data['doses_per_vial'] );
+	}
+
+	/**
+	 * calculate() accepts mg dose unit correctly.
+	 *
+	 * 5 mg / 2 mL / 0.5 mg → syringe units 20.
+	 */
+	public function test_calculate_mg_dose_unit(): void {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'vial_mg', '5' );
+		$request->set_param( 'water_ml', '2' );
+		$request->set_param( 'desired_dose', '0.5' );
+		$request->set_param( 'dose_unit', 'mg' );
+
+		$response = $this->controller->calculate( $request );
+		$data     = $response->get_data();
+
+		$this->assertEqualsWithDelta( 20.0, $data['syringe_units'], 0.1 );
+		$this->assertSame( 10.0, $data['doses_per_vial'] );
+	}
+
+	/**
+	 * calculate() returns all expected keys in the response data.
+	 */
+	public function test_calculate_response_has_expected_keys(): void {
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_param( 'vial_mg', '5' );
+		$request->set_param( 'water_ml', '2' );
+		$request->set_param( 'desired_dose', '250' );
+		$request->set_param( 'dose_unit', 'mcg' );
+
+		$data = $this->controller->calculate( $request )->get_data();
+
+		$expected_keys = [
+			'concentration_mg_per_ml',
+			'concentration_mcg_per_unit',
+			'injection_volume_ml',
+			'syringe_units',
+			'doses_per_vial',
+			'dose_unit',
+		];
+
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $data, "Missing key: $key" );
+		}
+	}
+
+	/**
+	 * get_presets() returns a 200 response with an array.
+	 */
+	public function test_get_presets_returns_200_with_array(): void {
+		$request  = new WP_REST_Request( 'GET' );
+		$response = $this->controller->get_presets( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertIsArray( $response->get_data() );
+	}
+
+	/**
+	 * get_preset() returns a WP_Error for an unknown slug.
+	 */
+	public function test_get_preset_unknown_slug_returns_wp_error(): void {
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'slug', 'nonexistent-peptide-xyz' );
+
+		$result = $this->controller->get_preset( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'prc_preset_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * get_preset() returns a 200 response for a known slug.
+	 */
+	public function test_get_preset_known_slug_returns_200(): void {
+		$request = new WP_REST_Request( 'GET' );
+		$request->set_param( 'slug', 'bpc-157' );
+
+		$result = $this->controller->get_preset( $request );
+
+		$this->assertInstanceOf( WP_REST_Response::class, $result );
+		$this->assertSame( 200, $result->get_status() );
+
+		$data = $result->get_data();
+		$this->assertSame( 'bpc-157', $data['slug'] );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -19,7 +19,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 global $wpdb;
 
 // Delete all prc_ prefixed options.
-$wpdb->query(
+$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$wpdb->prepare(
 		"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
 		$wpdb->esc_like( 'prc_' ) . '%'
@@ -27,7 +27,7 @@ $wpdb->query(
 );
 
 // Delete all prc_ prefixed transients.
-$wpdb->query(
+$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	$wpdb->prepare(
 		"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s OR option_name LIKE %s",
 		$wpdb->esc_like( '_transient_prc_' ) . '%',

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,6 +7,7 @@
  * Dependencies: None (standalone, no autoloader).
  *
  * @see ARCHITECTURE.md — Teardown section.
+ * @package PeptideReconstitutionCalculator
  */
 
 declare(strict_types=1);


### PR DESCRIPTION
## What
- Replace standalone `ci.yml` with thin caller to estate reusable workflow (`peptide-e2e/.github/workflows/ci.yml@main`; `tests: stubs`, `has_js: true`, `permissions: contents: write`, `workflow_call` so `deploy.yml` gate works).
- Write PHPUnit test suite from zero — 40 tests across 4 classes:
  - **MathTest (25)**: all `PRC_Math` public methods + `calculate()` orchestrator with real peptide scenarios (BPC-157, TB-500, Semaglutide, MK-677, Ipamorelin) plus edge cases (zero water, negative inputs, floor rounding, rounding precision, mcg↔mg unit conversion).
  - **DefaultPresetsTest (11)**: all 8 slugs present, required keys on every preset (dataProvider), valid dose units, min<max range, source=default, spot-checks on BPC-157/Semaglutide/MK-677.
  - **RestControllerTest (7)**: `calculate()` 200 + correct values for both mcg and mg dose units; `get_presets()` 200; `get_preset()` 200 for known slug and `WP_Error` for unknown.
  - **PresetProviderTest (4)**: fallback to defaults without PR Core, all presets have slug, cache invalidation, idempotent invalidation.
- `phpunit.xml.dist` + `tests/bootstrap.php` (WP function/class stubs, WP_REST_Request stub, WP_REST_Response stub, WP_Error stub).
- `composer test` → `vendor/bin/phpunit --configuration phpunit.xml.dist`.
- `phpunit/phpunit ^9.6` + `yoast/phpunit-polyfills ^2.0` added to `require-dev`.
- `deploy.yml` unchanged — already gates on `./ci.yml` + `deploy-app.yml`.
- Version bump 1.1.0 → 1.2.0.

## Why
Estate CI wave 3 (CTO thread #21). Plugin had zero tests.

## Risk flags
- None. Pure additions + CI config replacement. No plugin logic changed.
- `tests/bootstrap.php` WP stubs follow the identical pattern from `peptide-news-plugin` (estate reference).
- 300-line rule applies to `includes/` only — `tests/` are excluded in both `phpcs.xml.dist` and the reusable CI default.

## Test plan
- CI green on this PR: phpunit (stubs), phpcs, lint-php (8.1/8.2/8.3), file-size, lint-js.
- Math cases verified manually from formulas in `class-prc-math.php`.