### PR TITLE
ci: fix peptide-e2e reusable-workflow org ref (peptiderepo→peptide-repo)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@
 #
 # Delegates all lint/test/file-size jobs to the estate reusable workflow.
 # Per estate standard: workflow_call is required so deploy.yml can gate on it.
-# See: peptiderepo/peptide-e2e/.github/workflows/ci.yml@main for job definitions.
+# See: peptide-repo/peptide-e2e/.github/workflows/ci.yml@main for job definitions.
 ##
 name: CI
 
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   ci:
-    uses: peptiderepo/peptide-e2e/.github/workflows/ci.yml@main
+    uses: peptide-repo/peptide-e2e/.github/workflows/ci.yml@main
     with:
       tests: stubs
       has_js: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
   deploy:
     name: Deploy (shared pipeline)
     needs: ci
-    uses: peptiderepo/peptide-e2e/.github/workflows/deploy-app.yml@main
+    uses: peptide-repo/peptide-e2e/.github/workflows/deploy-app.yml@main
     with:
       target_path: wp-content/plugins/peptide-reconstitution-calculator
     secrets: inherit


### PR DESCRIPTION
## What changed
Updated stale `peptiderepo/peptide-e2e` references to `peptide-repo/peptide-e2e` in workflow `uses:` fields (ci.yml, deploy.yml).

## Why
GitHub's 2026-06-16 org migration moved repos from `peptiderepo` user to `peptide-repo` org. Reusable workflow `uses:` refs do NOT follow transfer redirects. This is a pure mechanical string fix.

## Risk flags
Low. Only the org owner-string changes. No logic, secrets, steps, or `runs-on` lines touched.

## Test plan
CI should now resolve the shared pipeline from the correct org. Deploy jobs run on `peptide-vps` runner.